### PR TITLE
HTTPで仮ログインできるように修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,4 +3,15 @@ class UsersController < ApplicationController
     user = User.find_by(id: session[:user_id])
     @favorites = user.foods
   end
+
+  def auth_done
+    user_name = "Test"
+
+    # find_or_create_byメソッドが使える
+    user = User.find_by(name: user_name) || User.create(name: user_name)
+    user.save
+    session[:user_id] = user.id
+
+    redirect_to :root
+  end
 end

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -53,7 +53,7 @@
     <%= link_to 'New Knowledge', new_food_path, class: "btn btn-light btn-sm buttons" %>
   <% end %>
   <% unless @user_name %>
-    <%= link_to '/auth/facebook' do %>
+    <%= link_to login_path do %>
       <%= image_tag '/facebook-logo.png', class: "facebook-lg" %>
     <% end %>
   <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   get '/user', to: 'users#index'
   get '/auth/facebook/callback', to: 'facebook#auth_done'
   delete '/', to: 'sessions#destroy'
+  get '/login', to: 'users#auth_done'
 end


### PR DESCRIPTION
アプリの仕様上、ログインをした状態でないとほとんどの機能が使えないため、HTTPSを強制するFacebook認証を避け、仮ログインを行えるよう修正致した
