### PR TITLE
HOTFIX - ファイル無添付の状態だと検索時に表示できない不具合の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /storage/*
 !/storage/.keep
 
+/vendor/bundle
 /node_modules
 /yarn-error.log
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    rb-readline (0.5.5)
     regexp_parser (1.3.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -319,6 +320,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-ujs
   ransack
+  rb-readline
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -91,7 +91,11 @@
           </div>
         </div>
         <div class="container" style="display: inline-block;">
-          <span class="image_part"><%= image_tag food.image, class: "image_size" %></span>
+          <span class="image_part">
+            <% if food.image.attached? %>
+              <%= image_tag food.image, class: "image_size" %>
+            <% end %>
+          </span>
           <div style="float: left;">
             <h5 class="how_to_title">美味しい<%= food.name %>の選び方!!</h5>
             <% food.points.each do |point| %>


### PR DESCRIPTION
第一回の開催時に問題となっていた件の暫定対応分の反映です。

…といいつつ、ついでに以下の運用上の問題について修正を図っています。

* `bundle install` した際に Gemfile.lock に発生する差分の適用
* `bundle install` 先として想定している vendor/bundle ディレクトリをバージョン管理対象外に設定