### PR TITLE
Rename .spec and overwrite .rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/.spec
+++ b/.spec
@@ -1,2 +1,0 @@
---require spec_helper
---format documentation


### PR DESCRIPTION
まず、ファイル名に誤りがあります。.spec は RSpec の設定ファイル名としては正しくありません。正しくは、 .rspec です。

次にファイルの中身は、.spec の方が望ましいと判断しましたので、.spec を .rspecにリネームしています。