### PR TITLE
Food image required

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem 'omniauth-facebook'
 gem 'ransack'
 gem 'rails-ujs'
 
+# Temporarily introduced up to Rails 6.1
+# Rails PR https://github.com/rails/rails/pull/35390
+gem 'active_storage_validations'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_storage_validations (0.8.2)
+      rails (>= 5.2.0)
     activejob (5.2.2)
       activesupport (= 5.2.2)
       globalid (>= 0.3.6)
@@ -298,6 +300,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_storage_validations
   bootsnap (>= 1.1.0)
   bxslider-rails
   byebug
@@ -337,4 +340,4 @@ RUBY VERSION
    ruby 2.5.3
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -21,7 +21,6 @@ class FoodsController < ApplicationController
       unless @food.valid?
         @point = Point.all
         @food.errors.add(:point, "Point select please.") unless params[:point].present?
-        @food.errors.add(:image, "select please.") unless params[:image].present?
         render :new and return
       end
 

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -7,6 +7,8 @@ class Food < ApplicationRecord
     validates :name, :description, presence: true
     # validates :points, presence: true
 
+    validates :image, attached: true
+
     validates :name, length: { maximum: 10 }
     validates :description, length: { maximum: 300 }
     validates :points, length: { maximum: 3, minmum: 1 }

--- a/spec/system/validation_spec.rb
+++ b/spec/system/validation_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'validation test', type: :system do
         visit 'foods/new'
         click_on 'submit'
 
-        expect(page).to have_content 'Image select please.'
+        expect(page).to have_content %w(Image can't be blank)
       end
     end
   end


### PR DESCRIPTION
`Food` の `Image` を必須入力にしました。
`active_storage_validations` という gem を使用するように変更しています。
[Rails 6.1 で ActiveStorage に `attached` バリデーションが追加](https://github.com/rails/rails/pull/35390)されます。
`active_storage_validations ` の導入は Rails 6.1 に上げるまでの一時的なものです。

closes: #7 
