### PR TITLE
Fix #60 - Food.description の必須指定を削除

### DIFF
--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -7,7 +7,7 @@ class Food < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_one_attached :image
 
-  validates :name, :description, presence: true
+  validates :name, presence: true
   # validates :points, presence: true
 
   validates :image, attached: true


### PR DESCRIPTION
表題のとおり #60 の修正です。
対応時の検証としては以下を行なっています。

- 空での登録が可能となっていること
- 空での登録を行ったレコードについて、表示が可能であること
  - Foods#index
  - Users#index